### PR TITLE
Avoid password leak when Ansible run with --diff

### DIFF
--- a/roles/conman/tasks/main.yml
+++ b/roles/conman/tasks/main.yml
@@ -14,6 +14,7 @@
     group: root
     content: "{{ conman_file_conf }}"
   when: conman_file_conf is defined
+  no_log: true
   notify: Restart conman
 
 - name: Set /etc/default/conman.conf

--- a/roles/powerman/tasks/main.yml
+++ b/roles/powerman/tasks/main.yml
@@ -17,6 +17,7 @@
   loop_control:
     label: "/etc/freeipmi/freeipmi-{{ item.key }}.conf"
   when: freeipmi_conf is defined
+  no_log: true
   notify: Restart powerman
 
 - name: Set /etc/powerman/powerman.conf


### PR DESCRIPTION
Both tasks write BMC passwords in the configuration files. Make sure the password won't be displayed in the logs when `--diff` is used.