### PR TITLE
Add condition for 'apparmor.d/local/'

### DIFF
--- a/roles/apparmor/defaults/main.yml
+++ b/roles/apparmor/defaults/main.yml
@@ -10,7 +10,7 @@ apparmor_service_state: started
 
 # apparmor_profiles:
 #   - dest: /etc/apparmor.d/apptainer
-#     # state: absent
+#     state: present
 #     content: |
 #       # Permit unprivileged user namespace creation for apptainer starter
 #       abi <abi/4.0>,
@@ -20,3 +20,11 @@ apparmor_service_state: started
 #         # Site-specific additions and overrides. See local/README for details.
 #         include if exists <local/apptainer>
 #       }
+#
+#   - dest: /etc/apparmor.d/local/usr.sbin.cupsd
+#     state: absent
+#     content: |
+#       # Local customizations for CUPS daemon
+#       /var/log/cups/custom.log w,
+#       /etc/cups/custom.conf r,
+#       /opt/printer-driver/** rx,

--- a/roles/apparmor/tasks/main.yml
+++ b/roles/apparmor/tasks/main.yml
@@ -27,6 +27,7 @@
   when:
     - apparmor_profiles is defined
     - item.state is defined and item.state == "absent"
+    - "'/etc/apparmor.d/local/' not in item.dest"
   register: __apparmor_remove
   failed_when:
     - __apparmor_remove.failed

--- a/roles/apparmor/tasks/main.yml
+++ b/roles/apparmor/tasks/main.yml
@@ -27,7 +27,7 @@
   when:
     - apparmor_profiles is defined
     - item.state is defined and item.state == "absent"
-    - "'/etc/apparmor.d/local/' not in item.dest"
+    - "'/etc/apparmor.d/local/' not in item.dest"  # don't run on files in the local subdirectory
   register: __apparmor_remove
   failed_when:
     - __apparmor_remove.failed


### PR DESCRIPTION
Do not call the `apparmor_parser --remove` command when deleting a file in the local subdirectory.